### PR TITLE
[Fix] MSR_EFFR_LME instead of MSR_EFER_LME_BIT

### DIFF
--- a/arch/x86/boot/boot.S
+++ b/arch/x86/boot/boot.S
@@ -184,7 +184,7 @@ enable_paging:
 	/* Enable long mode */
 	mov $MSR_EFER, %ecx
 	rdmsr
-	or $(MSR_EFER_LME_BIT), %eax
+	or $(MSR_EFER_LME), %eax
 	wrmsr
 
 	/* Enable paging */


### PR DESCRIPTION
boot.S에 typo로 인한 부팅 실패 fix